### PR TITLE
Adds binary serialization/deserialization

### DIFF
--- a/lib/macaroons.rb
+++ b/lib/macaroons.rb
@@ -3,11 +3,11 @@ require 'macaroons/macaroons'
 module Macaroon
   class << self
     def new(location, identifier, key)
-      Macaroons::Macaroon.new(location, identifier, key)
+      Macaroons::Macaroon.new(location:location, identifier:identifier, key:key)
     end
 
     def from_binary(serialized)
-      Macaroons::Macaroon.new(nil, nil, nil).from_binary(serialized)
+      Macaroons::Macaroon.from_binary(serialized)
     end
   end
 end

--- a/lib/macaroons/macaroons.rb
+++ b/lib/macaroons/macaroons.rb
@@ -2,8 +2,8 @@ require 'macaroons/raw_macaroon'
 
 module Macaroons
   class Macaroon
-    def initialize(key, identifier, location)
-      @raw_macaroon = RawMacaroon.new(key, identifier, location)
+    def initialize(key: nil, identifier: nil, location: nil, raw_macaroon: nil)
+      @raw_macaroon = raw_macaroon || RawMacaroon.new(key: key, identifier: identifier, location: location)
     end
 
     def identifier
@@ -22,9 +22,9 @@ module Macaroons
       @raw_macaroon.caveats
     end
 
-    def from_binary(serialized)
-      @raw_macaroon = RawMacaroon.new(nil, nil, nil, serialized=serialized)
-      self
+    def self.from_binary(serialized)
+      raw_macaroon = RawMacaroon.new(serialized: serialized)
+      macaroon = Macaroons::Macaroon.new(raw_macaroon: raw_macaroon)
     end
 
     def serialize()
@@ -44,7 +44,7 @@ module Macaroons
     end
 
     def third_party_caveats
-      caveats.select{|caveat| caveat.third_party?}
+      caveats.select(&:third_party?)
     end
 
   end


### PR DESCRIPTION
This adds binary serialization/deserialization for macaroons. I verified that the serialized text is the same as for the python library. (A little more work should be done - serializing a macaroon with first and third party caveats and loading them into the python library along with discharge macaroons and vice-versa).

Wouldn't mind suggestions on the creation patterns here. The external interface is good (I think) but the internal passes a lot of nils around (I guess that's fine, though).

Example:

``` ruby
m = Macaroon.new('123', '456', 'http://localmed.com')
m.add_first_party_caveat('caveat_1')
m.add_third_party_caveat('caveat_key', 'caveat_id', 'http://localmed')
n = Macaroon.from_binary(m.serialize)
m
=> #<Macaroons::Macaroon:0x007fc08d0bc368 @raw_macaroon=#<Macaroons::RawMacaroon:0x007fc08d0bc1d8 @key="123", @identifier="456", @location="http://localmed.com", @signature="WE\xFE3\x0E=&zEFP\xC8>,\xE7\xF61Nh\xC5$\xEC\xA9\xEE\xA5\xFD\x90\x82&\xF4\x9B\x18", @caveats=[#<Macaroons::Caveat:0x007fc08d0d75c8 @caveat_id="caveat_1", @verification_id=nil, @caveat_location=nil>, #<Macaroons::Caveat:0x007fc08d0ec1a8 @caveat_id="caveat_id", @verification_id="sovf8T2TAjnxWDvVFSR5MLQ1ukPwndwkTzBCjjqU6btaFAL+Y+ini3SIna1s\nluU2c3SDRB8+GlfzJLk6fBuDcbY1vetjDLul\n", @caveat_location="http://localmed">]>>
n
=> #<Macaroons::Macaroon:0x007fc08d10db00 @raw_macaroon=#<Macaroons::RawMacaroon:0x007fc08d10da60 @key=nil, @identifier="456", @location="http://localmed.com", @signature="WE\xFE3\x0E=&zEFP\xC8>,\xE7\xF61Nh\xC5$\xEC\xA9\xEE\xA5\xFD\x90\x82&\xF4\x9B\x18", @caveats=[#<Macaroons::Caveat:0x007fc08d116958 @caveat_id="caveat_1", @verification_id=nil, @caveat_location=nil>, #<Macaroons::Caveat:0x007fc08d115c88 @caveat_id="caveat_id", @verification_id="sovf8T2TAjnxWDvVFSR5MLQ1ukPwndwkTzBCjjqU6btaFAL+Y+ini3SIna1s\nluU2c3SDRB8+GlfzJLk6fBuDcbY1vetjDLul\n", @caveat_location="http://localmed">]>>
```

@joeljames @petebrowne 
