### PR TITLE
fixed typo

### DIFF
--- a/lib/macaroons/serializers/json.rb
+++ b/lib/macaroons/serializers/json.rb
@@ -18,7 +18,7 @@ module Macaroons
       macaroon = Macaroons::RawMacaroon.new(key: 'no_key', identifier: deserialized['identifier'], location: deserialized['location'])
       deserialized['caveats'].each do |c|
         caveat = Macaroons::Caveat.new(c['cid'], c['vid'], c['cl'])
-        macaroon.caveats << c
+        macaroon.caveats << caveat
       end
       macaroon.signature = Utils.unhexlify(deserialized['signature'])
       macaroon


### PR DESCRIPTION
which caused nasty exception when JSON serialization was used

```
/Users/kron/tmp/ruby/macaroons/.gems/ruby/2.1.0/gems/macaroons-0.4.0/lib/macaroons/verifier.rb:52:in `block in verify_caveats': undefined method `first_party?' for {"cid"=>"space:breakout", "vid"=>nil, "cl"=>nil}:Hash (NoMethodError)
    from /Users/kron/tmp/ruby/macaroons/.gems/ruby/2.1.0/gems/macaroons-0.4.0/lib/macaroons/verifier.rb:51:in `each'
    from /Users/kron/tmp/ruby/macaroons/.gems/ruby/2.1.0/gems/macaroons-0.4.0/lib/macaroons/verifier.rb:51:in `verify_caveats'
    from /Users/kron/tmp/ruby/macaroons/.gems/ruby/2.1.0/gems/macaroons-0.4.0/lib/macaroons/verifier.rb:36:in `verify_discharge'
    from /Users/kron/tmp/ruby/macaroons/.gems/ruby/2.1.0/gems/macaroons-0.4.0/lib/macaroons/verifier.rb:30:in `verify'
```
