### PR TITLE
Improve method delegation support

### DIFF
--- a/lib/macaroons.rb
+++ b/lib/macaroons.rb
@@ -1,24 +1,6 @@
 require 'macaroons/macaroons'
 require 'macaroons/verifier'
 
-module Macaroon
-  class << self
-    def new(location: location, identifier: identifier, key: key)
-      Macaroons::Macaroon.new(location:location, identifier:identifier, key:key)
-    end
-
-    def from_binary(serialized)
-      Macaroons::Macaroon.from_binary(serialized)
-    end
-
-    def from_json(serialized)
-      Macaroons::Macaroon.from_json(serialized)
-    end
-  end
-
-  class Verifier
-    def self.new()
-      Macaroons::Verifier.new()
-    end
-  end
+class Macaroon < Macaroons::Macaroon
+  class Verifier < Macaroons::Verifier; end
 end

--- a/lib/macaroons/macaroons.rb
+++ b/lib/macaroons/macaroons.rb
@@ -1,26 +1,17 @@
+require 'forwardable'
+
 require 'macaroons/raw_macaroon'
 
 module Macaroons
   class Macaroon
+    extend Forwardable
+
     def initialize(key: nil, identifier: nil, location: nil, raw_macaroon: nil)
       @raw_macaroon = raw_macaroon || RawMacaroon.new(key: key, identifier: identifier, location: location)
     end
 
-    def identifier
-      @raw_macaroon.identifier
-    end
-
-    def location
-      @raw_macaroon.location
-    end
-
-    def signature
-      @raw_macaroon.signature
-    end
-
-    def caveats
-      @raw_macaroon.caveats
-    end
+    def_delegators :@raw_macaroon, :identifier, :location, :signature, :caveats,
+      :serialize, :serialize_json, :add_first_party_caveat, :add_third_party_caveat, :prepare_for_request
 
     def self.from_binary(serialized)
       raw_macaroon = RawMacaroon.from_binary(serialized: serialized)
@@ -32,32 +23,13 @@ module Macaroons
       macaroon = Macaroons::Macaroon.new(raw_macaroon: raw_macaroon)
     end
 
-    def serialize
-      @raw_macaroon.serialize()
-    end
-
-    def serialize_json
-      @raw_macaroon.serialize_json()
-    end
-
-    def add_first_party_caveat(predicate)
-      @raw_macaroon.add_first_party_caveat(predicate)
-    end
-
     def first_party_caveats
       caveats.select(&:first_party?)
-    end
-
-    def add_third_party_caveat(caveat_key, caveat_id, caveat_location)
-      @raw_macaroon.add_third_party_caveat(caveat_key, caveat_id, caveat_location)
     end
 
     def third_party_caveats
       caveats.select(&:third_party?)
     end
 
-    def prepare_for_request(macaroon)
-      @raw_macaroon.prepare_for_request(macaroon)
-    end
   end
 end


### PR DESCRIPTION
Remove hard-coded method delegation using inheritance and the [`Forwardable`](http://www.rubydoc.info/stdlib/forwardable/Forwardable) module.