### PR TITLE
Use rbnacl-libsodium gem

### DIFF
--- a/lib/macaroons/raw_macaroon.rb
+++ b/lib/macaroons/raw_macaroon.rb
@@ -1,6 +1,6 @@
 require 'base64'
 
-require 'rbnacl'
+require 'rbnacl/libsodium'
 
 require 'macaroons/caveat'
 require 'macaroons/utils'

--- a/lib/macaroons/verifier.rb
+++ b/lib/macaroons/verifier.rb
@@ -1,4 +1,4 @@
-require 'rbnacl'
+require 'rbnacl/libsodium'
 
 require 'macaroons/errors'
 

--- a/macaroons.gemspec
+++ b/macaroons.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = "~> 2.0"
   spec.add_dependency "multi_json", "~> 1.10.1"
-  spec.add_dependency "rbnacl", "~> 3.1.2"
+  spec.add_dependency "rbnacl", "~> 3.2"
+  spec.add_dependency "rbnacl-libsodium", "~> 1.0"
 
   spec.add_development_dependency "bundler", "> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This gem includes a full distribution of libsodium, which compiles under both CRuby and JRuby.

I keep it up-to-date with upstream libsodium. Releases lag by a few days at most. It should assist in installing this gem.