### PR TITLE
travis.yml configuration updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ rvm:
   - 2.1.10
   - 2.0.0
 cache: bundler
-script: bundle exec rspec .
+script: bundle exec rspec
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - ./configure && make && make check && sudo make install
   - sudo ldconfig
   - cd ..
+cache: bundler
 install: "bundle install"
 script: rspec .
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,5 @@ before_install:
   - sudo ldconfig
   - cd ..
 cache: bundler
-install: "bundle install"
 script: rspec .
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ rvm:
   - 2.1.10
   - 2.0.0
 cache: bundler
-script: rspec .
+script: bundle exec rspec .
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.0
+  - 2.3.1
+  - 2.2.5
+  - 2.1.10
   - 2.0.0
 before_install:
   - wget https://github.com/jedisct1/libsodium/releases/download/0.7.0/libsodium-0.7.0.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ rvm:
   - 2.2.5
   - 2.1.10
   - 2.0.0
-before_install:
-  - wget https://github.com/jedisct1/libsodium/releases/download/0.7.0/libsodium-0.7.0.tar.gz
-  - tar xzvf libsodium-0.7.0.tar.gz
-  - cd libsodium-0.7.0
-  - ./configure && make && make check && sudo make install
-  - sudo ldconfig
-  - cd ..
 cache: bundler
 script: rspec .
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 2.3.1


### PR DESCRIPTION
Adds the rest of 2.X ruby versions and speeds up the Travis run when the libsodium gem is cached.